### PR TITLE
[pfc] Http Cache-Control Validation

### DIFF
--- a/src/XProtocol/XProtocol.hh
+++ b/src/XProtocol/XProtocol.hh
@@ -620,6 +620,7 @@ enum XQueryType {
    kXR_Qckscan= 6,
    kXR_Qconfig= 7,
    kXR_Qvisa  = 8,
+   kXR_Qhead  = 9,
    kXR_Qopaque=16,
    kXR_Qopaquf=32,
    kXR_Qopaqug=64

--- a/src/XrdCl/XrdClFile.hh
+++ b/src/XrdCl/XrdClFile.hh
@@ -599,7 +599,7 @@ namespace XrdCl
                           Buffer          *&response,
                           uint16_t          timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
-
+files
       //------------------------------------------------------------------------
       //! Get access token to a file - async
       //!

--- a/src/XrdCl/XrdClFile.hh
+++ b/src/XrdCl/XrdClFile.hh
@@ -599,7 +599,7 @@ namespace XrdCl
                           Buffer          *&response,
                           uint16_t          timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
-files
+
       //------------------------------------------------------------------------
       //! Get access token to a file - async
       //!

--- a/src/XrdCl/XrdClFileSystem.hh
+++ b/src/XrdCl/XrdClFileSystem.hh
@@ -60,6 +60,7 @@ namespace XrdCl
       Space          = kXR_Qspace,     //!< Query logical space stats
       Stats          = kXR_QStats,     //!< Query server stats
       Visa           = kXR_Qvisa,      //!< Query file visa attributes
+      Head           = kXR_Qhead,      //!< Query http header response
       XAttr          = kXR_Qxattr      //!< Query file extended attributes
     };
   };

--- a/src/XrdOuc/XrdOucCache.hh
+++ b/src/XrdOuc/XrdOucCache.hh
@@ -36,6 +36,7 @@
 
 #include "XrdOuc/XrdOucCacheStats.hh"
 #include "XrdOuc/XrdOucIOVec.hh"
+#include "XrdCl/XrdClBuffer.hh"
 
 struct stat;
 class  XrdOucEnv;
@@ -146,6 +147,20 @@ long long    FSize() = 0;
 //------------------------------------------------------------------------------
 
 virtual int  Fstat(struct stat &sbuff) {(void)sbuff; return 1;}
+
+
+//------------------------------------------------------------------------------
+//! Perform an fcntl() operation (defaults to passthrough).
+//!
+//! @param  AMT, for the moment XrdCl::Buffer to pass query code value and
+//!         XrdCl::Buffer to pass the string response. The XrdCL::Buffers is
+//!         interpreted as std::string
+//!
+//! @return <0 - fstat failed, value is -errno.
+//!         =0 - fstat succeeded, sbuff holds stat information.
+//!         >0 - fstat could not be done, forward operation to next level.
+//------------------------------------------------------------------------------
+virtual int Fcntl(const XrdCl::Buffer& args, XrdCl::Buffer*& res) { return -1; }
 
 //-----------------------------------------------------------------------------
 //! Get the file's location (i.e. endpoint hostname and port)

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1181,7 +1181,7 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
             XrdCl::Buffer queryArgs(500);
             queryArgs.FromString(curl); // pass file path throug args
             XrdCl::Buffer *response = nullptr;
-            XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::XAttr, queryArgs, response);
+            XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Head, queryArgs, response);
 
             if (st.IsOK())
             {

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1131,7 +1131,7 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
    queryArgs.FromString(curl); // pass parh throug args
    XrdCl::Buffer* response = nullptr;
 
-   XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Space, queryArgs, response);
+   XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::XAttr, queryArgs, response);
 
    std::cout << st.GetShellCode() << " resp in buffer:" << response << "\n";
    if (st.IsOK()) {

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -451,10 +451,10 @@ File* Cache::GetFile(const std::string& path, IO* io, long long off, long long f
       if (resFctl == 0)
       {
          // seems like success
-         std::cout << "Cache::GetFile ...  IO Query result buffer " << responseFctl->ToString() << "\n";
+         std::cout << "Cache::GetFile ...  Fctl result buffer " << responseFctl->ToString() << "\n";
       }
       else {
-         std::cout << "Cache::GetFile IO query to origin failed \n";
+         std::cout << "Cache::GetFile Fctl to origin failed \n";
       }
    }
 

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1207,13 +1207,13 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
             }
          }
 
-
          if (!ccIsValid)
          {
             // invalidate cinfo on ETag mismatch
             UnlinkFile(f_name, false);
          }
-      }
+      } // end chekcing cache control xattr in cinfo file
+
       return 1;
    }
    else

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1201,7 +1201,9 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
             }
             else
             {
+               // Message has a status beacuse we are in the block condition for cache-contol xattr
                TRACE(Error, "Prepare() XrdCl::FileSystem::Query failed " << f_name.c_str());
+               ccIsValid = false;
             }
          }
 

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1178,8 +1178,8 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
             // Compare cinfo xattr etag and the etag from file system query response
             // Note: qeury returns only etag value, not a json string
             XrdCl::FileSystem fs(url);
-            XrdCl::Buffer queryArgs(500);
-            queryArgs.FromString(curl); // pass file path throug args
+            XrdCl::Buffer queryArgs(1024); // pass file path throug args: reserve bytes to store path
+            queryArgs.FromString(curl);
             XrdCl::Buffer *response = nullptr;
             XrdCl::XRootDStatus st = fs.Query(XrdCl::QueryCode::Head, queryArgs, response);
 
@@ -1211,7 +1211,6 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
          if (!ccIsValid)
          {
             // invalidate cinfo on ETag mismatch
-            // AMT ...what to do with the second fail_if_open argument ?
             UnlinkFile(f_name, false);
          }
       }

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -448,7 +448,7 @@ File* Cache::GetFile(const std::string& path, IO* io, long long off, long long f
 
    if (filesize >= 0)
    {
-      file = File::FileOpen(path, off, filesize, io->Base());
+      file = File::FileOpen(path, off, filesize, io->GetInput());
    }
 
    {
@@ -917,7 +917,7 @@ void Cache::WriteCacheControlXAttr(int cinfo_fd, const char* path, const std::st
    if (m_metaXattr) {
       int res = XrdSysXAttrActive->Set("pfc.cache-control", cc.c_str(), cc.size(), path, cinfo_fd, 0);
       if (res != 0) {
-         TRACE(Debug, "WriteFileSizeXAttr error setting xattr " << res);
+         TRACE(Error, "WritecacheControlXAttr error setting xattr " << res);
       }
    }
 }
@@ -993,9 +993,8 @@ int Cache::GetCacheControlXAttr(const std::string &cinfo_fname, std::string& iva
       {
          std::string tmp(cc, res);
          ival = tmp;
-         //ival.assign(tmp);
-         return res;
       }
+      return res;
    }
    return 0;
 }

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -440,6 +440,22 @@ File* Cache::GetFile(const std::string& path, IO* io, long long off, long long f
       } else {
          filesize = st.st_size;
       }
+
+      XrdCl::QueryCode::Code queryCode = XrdCl::QueryCode::XAttr; // tmp ... should be XrdCl::QueryCode::ETag ????
+      XrdCl::Buffer queryArgs(5);
+      std::string qs =  std::to_string(queryCode);
+      queryArgs.FromString(qs);
+
+      XrdCl::Buffer* responseFctl = nullptr;
+      int resFctl = io->Base()->Fcntl(queryArgs, responseFctl);
+      if (resFctl == 0)
+      {
+         // seems like success
+         std::cout << "Cache::GetFile ...  IO Query result buffer " << responseFctl->ToString() << "\n";
+      }
+      else {
+         std::cout << "Cache::GetFile IO query to origin failed \n";
+      }
    }
 
    File *file = 0;

--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -186,8 +186,12 @@ public:
    virtual int ConsiderCached(const char *url);
 
    bool DecideIfConsideredCached(long long file_size, long long bytes_on_disk);
+   void WriteCacheControlXAttr(int cinfo_fd, const std::string& cc);
    void WriteFileSizeXAttr(int cinfo_fd, long long file_size);
    long long DetermineFullFileSize(const std::string &cinfo_fname);
+   int GetCacheControlXAttr(const std::string &cinfo_fname, std::string& res);
+   int GetCacheControlXAttr(int fd, std::string& res);
+
 
    //--------------------------------------------------------------------
    //! \brief Makes decision if the original XrdOucCacheIO should be cached.

--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -186,7 +186,7 @@ public:
    virtual int ConsiderCached(const char *url);
 
    bool DecideIfConsideredCached(long long file_size, long long bytes_on_disk);
-   void WriteCacheControlXAttr(int cinfo_fd, const std::string& cc);
+   void WriteCacheControlXAttr(int cinfo_fd, const char* path, const std::string& cc);
    void WriteFileSizeXAttr(int cinfo_fd, long long file_size);
    long long DetermineFullFileSize(const std::string &cinfo_fname);
    int GetCacheControlXAttr(const std::string &cinfo_fname, std::string& res);

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -537,7 +537,7 @@ bool File::Open(XrdOucCacheIO* inputIO)
 
       // access and write cache-control attributes
       std::string cc_str;
-      XrdCl::QueryCode::Code queryCode = XrdCl::QueryCode::XAttr;
+      XrdCl::QueryCode::Code queryCode = XrdCl::QueryCode::Head;
       XrdCl::Buffer queryArgs(5);
       std::string qs = std::to_string(queryCode);
       queryArgs.FromString(qs);

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -536,7 +536,7 @@ bool File::Open(XrdOucCacheIO* inputIO)
       cache()->WriteFileSizeXAttr(m_info_file->getFD(), m_file_size);
 
       // access and write cache-control attributes
-      std::string ccjson;
+      std::string cc_str;
       XrdCl::QueryCode::Code queryCode = XrdCl::QueryCode::XAttr;
       XrdCl::Buffer queryArgs(5);
       std::string qs = std::to_string(queryCode);
@@ -545,18 +545,17 @@ bool File::Open(XrdOucCacheIO* inputIO)
       int resFctl = inputIO->Fcntl(queryArgs, responseFctl);
       if (resFctl == 0)
       {
-         ccjson = responseFctl->ToString();
-         nlohmann::json j =  nlohmann::json::parse(ccjson);
-         std::cout << j.dump(2) << " ====\n";
-         if (j.contains("max-age"))
+         cc_str = responseFctl->ToString();
+         nlohmann::json cc_json =  nlohmann::json::parse(cc_str);
+         if (cc_json.contains("max-age"))
          {
-            time_t ma = j["max-age"];
+            time_t ma = cc_json["max-age"];
             ma += time(NULL);
-            j["expire"] = ma;
-            ccjson = j.dump();
+            cc_json["expire"] = ma;
+            cc_str = cc_json.dump();
          }
-         TRACE(Debug, "GetFile() XrdCl::File::Fcntl value " << ccjson);
-         cache()->WriteCacheControlXAttr(m_info_file->getFD(), nullptr, ccjson);
+         TRACE(Debug, "GetFile() XrdCl::File::Fcntl value " << cc_str);
+         cache()->WriteCacheControlXAttr(m_info_file->getFD(), nullptr, cc_str);
       }
       else
       {

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -548,7 +548,8 @@ bool File::Open(XrdOucCacheIO* inputIO)
          ccjson = responseFctl->ToString();
          nlohmann::json j =  nlohmann::json::parse(ccjson);
          std::cout << j.dump(2) << " ====\n";
-         if (j.contains("max-age")) {
+         if (j.contains("max-age"))
+         {
             time_t ma = j["max-age"];
             ma += time(NULL);
             j["expire"] = ma;

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -27,6 +27,7 @@
 #include "XrdSys/XrdSysTimer.hh"
 #include "XrdOss/XrdOss.hh"
 #include "XrdOuc/XrdOucEnv.hh"
+#include "XrdOuc/XrdOucJson.hh"
 #include "XrdSfs/XrdSfsInterface.hh"
 
 #include <cstdio>
@@ -50,7 +51,7 @@ const char *File::m_traceID = "File";
 
 //------------------------------------------------------------------------------
 
-File::File(const std::string& path, long long iOffset, long long iFileSize) :
+File::File(const std::string& path, long long iOffset, long long iFileSize, const std::string& json) :
    m_ref_cnt(0),
    m_data_file(0),
    m_info_file(0),
@@ -58,6 +59,7 @@ File::File(const std::string& path, long long iOffset, long long iFileSize) :
    m_filename(path),
    m_offset(iOffset),
    m_file_size(iFileSize),
+   m_cache_control(json),
    m_current_io(m_io_set.end()),
    m_ios_in_detach(0),
    m_non_flushed_cnt(0),
@@ -135,9 +137,9 @@ void File::Close()
 
 //------------------------------------------------------------------------------
 
-File* File::FileOpen(const std::string &path, long long offset, long long fileSize)
+File* File::FileOpen(const std::string &path, long long offset, long long fileSize, const std::string& json)
 {
-   File *file = new File(path, offset, fileSize);
+   File *file = new File(path, offset, fileSize, json);
    if ( ! file->Open())
    {
       delete file;
@@ -496,7 +498,7 @@ bool File::Open()
              ", data_size_from_last_block=" << m_cfi.GetExpectedDataFileSize() << ")");
 
       // Check if data file exists and is of reasonable size.
-      if (data_existed && data_stat.st_size >= m_cfi.GetExpectedDataFileSize())
+      if (data_existed && data_stat.st_size >= m_cfi.GetExpectedDataFileSize() && TestCCXAttr())
       {
          initialize_info_file = false;
       } else {
@@ -531,6 +533,8 @@ bool File::Open()
       m_cfi.Write(m_info_file, ifn.c_str());
       m_info_file->Fsync();
       cache()->WriteFileSizeXAttr(m_info_file->getFD(), m_file_size);
+      cache()->WriteCacheControlXAttr(m_info_file->getFD(), m_cache_control);
+      //
       TRACEF(Debug, tpfx << "Creating new file info, data size = " <<  m_file_size << " num blocks = "  << m_cfi.GetNBlocks());
    }
    else
@@ -1675,6 +1679,31 @@ std::string File::GetRemoteLocations() const
       s = "[]";
    }
    return s;
+}
+
+bool File::TestCCXAttr()
+{
+   std::string cc;
+   cache()->GetCacheControlXAttr(m_info_file->getFD(),cc);
+
+   nlohmann::json j1 = nlohmann::json::parse(cc);
+   nlohmann::json j2 = nlohmann::json::parse(m_cache_control);
+   if (j2.contains("ETag") ) {
+      if (j1.contains("ETag")) {
+         if (j1["ETag"] == j2["ETag"]) {
+            return true;
+         }
+         else {
+            TRACEF(Info, "XrdPfc::File::TestCCXAttr ETag mismatch");
+            return false;
+         }
+      }
+      else {
+         TRACEF(Info, "XrdPfc::File::TestCCXAttr. ETag entry missing");
+         return false;
+      }
+   }
+   return true;
 }
 
 //==============================================================================

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -30,6 +30,8 @@
 #include "XrdOuc/XrdOucJson.hh"
 #include "XrdSfs/XrdSfsInterface.hh"
 
+#include "XrdCl/XrdClFileStateHandler.hh"
+
 #include <cstdio>
 #include <sstream>
 #include <fcntl.h>
@@ -51,7 +53,7 @@ const char *File::m_traceID = "File";
 
 //------------------------------------------------------------------------------
 
-File::File(const std::string& path, long long iOffset, long long iFileSize, const std::string& json) :
+File::File(const std::string& path, long long iOffset, long long iFileSize) :
    m_ref_cnt(0),
    m_data_file(0),
    m_info_file(0),
@@ -59,7 +61,6 @@ File::File(const std::string& path, long long iOffset, long long iFileSize, cons
    m_filename(path),
    m_offset(iOffset),
    m_file_size(iFileSize),
-   m_cache_control(json),
    m_current_io(m_io_set.end()),
    m_ios_in_detach(0),
    m_non_flushed_cnt(0),
@@ -137,10 +138,10 @@ void File::Close()
 
 //------------------------------------------------------------------------------
 
-File* File::FileOpen(const std::string &path, long long offset, long long fileSize, const std::string& json)
+File* File::FileOpen(const std::string &path, long long offset, long long fileSize, XrdOucCacheIO* inputIO)
 {
-   File *file = new File(path, offset, fileSize, json);
-   if ( ! file->Open())
+   File *file = new File(path, offset, fileSize);
+   if ( ! file->Open(inputIO))
    {
       delete file;
       file = 0;
@@ -422,7 +423,7 @@ void File::RemoveIO(IO *io)
 
 //------------------------------------------------------------------------------
 
-bool File::Open()
+bool File::Open(XrdOucCacheIO* inputIO)
 {
    // Sets errno accordingly.
 
@@ -498,7 +499,7 @@ bool File::Open()
              ", data_size_from_last_block=" << m_cfi.GetExpectedDataFileSize() << ")");
 
       // Check if data file exists and is of reasonable size.
-      if (data_existed && data_stat.st_size >= m_cfi.GetExpectedDataFileSize() && TestCCXAttr())
+      if (data_existed && data_stat.st_size >= m_cfi.GetExpectedDataFileSize())
       {
          initialize_info_file = false;
       } else {
@@ -533,7 +534,34 @@ bool File::Open()
       m_cfi.Write(m_info_file, ifn.c_str());
       m_info_file->Fsync();
       cache()->WriteFileSizeXAttr(m_info_file->getFD(), m_file_size);
-      cache()->WriteCacheControlXAttr(m_info_file->getFD(), m_cache_control);
+
+      // access and write cache-control attributes
+      std::string ccjson;
+      XrdCl::QueryCode::Code queryCode = XrdCl::QueryCode::XAttr;
+      XrdCl::Buffer queryArgs(5);
+      std::string qs = std::to_string(queryCode);
+      queryArgs.FromString(qs);
+      XrdCl::Buffer *responseFctl = nullptr;
+      int resFctl = inputIO->Fcntl(queryArgs, responseFctl);
+      if (resFctl == 0)
+      {
+         ccjson = responseFctl->ToString();
+         nlohmann::json j =  nlohmann::json::parse(ccjson);
+         std::cout << j.dump(2) << " ====\n";
+         if (j.contains("max-age")) {
+            time_t ma = j["max-age"];
+            ma += time(NULL);
+            j["expire"] = ma;
+            ccjson = j.dump();
+         }
+         TRACE(Debug, "GetFile() XrdCl::File::Fcntl value " << ccjson);
+         cache()->WriteCacheControlXAttr(m_info_file->getFD(), nullptr, ccjson);
+      }
+      else
+      {
+         TRACE(Error, "GetFile() XrdCl::File::Fcntl query failed " << inputIO->Path());
+      }
+
       //
       TRACEF(Debug, tpfx << "Creating new file info, data size = " <<  m_file_size << " num blocks = "  << m_cfi.GetNBlocks());
    }
@@ -1679,31 +1707,6 @@ std::string File::GetRemoteLocations() const
       s = "[]";
    }
    return s;
-}
-
-bool File::TestCCXAttr()
-{
-   std::string cc;
-   cache()->GetCacheControlXAttr(m_info_file->getFD(),cc);
-
-   nlohmann::json j1 = nlohmann::json::parse(cc);
-   nlohmann::json j2 = nlohmann::json::parse(m_cache_control);
-   if (j2.contains("ETag") ) {
-      if (j1.contains("ETag")) {
-         if (j1["ETag"] == j2["ETag"]) {
-            return true;
-         }
-         else {
-            TRACEF(Info, "XrdPfc::File::TestCCXAttr ETag mismatch");
-            return false;
-         }
-      }
-      else {
-         TRACEF(Info, "XrdPfc::File::TestCCXAttr. ETag entry missing");
-         return false;
-      }
-   }
-   return true;
 }
 
 //==============================================================================

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -208,7 +208,7 @@ public:
    // Constructor, destructor, Open() and Close() are private.
 
    //! Static constructor that also does Open. Returns null ptr if Open fails.
-   static File* FileOpen(const std::string &path, long long offset, long long fileSize, const std::string& json);
+   static File* FileOpen(const std::string &path, long long offset, long long fileSize, XrdOucCacheIO*);
 
    //! Handle removal of a block from Cache's write queue.
    void BlockRemovedFromWriteQ(Block*);
@@ -292,7 +292,7 @@ public:
 
 private:
    //! Constructor.
-   File(const std::string &path, long long offset, long long fileSize, const std::string& xattrJson);
+   File(const std::string &path, long long offset, long long fileSize);
 
    //! Destructor.
    ~File();
@@ -301,7 +301,7 @@ private:
    void Close();
 
    //! Open file handle for data file and info file on local disk.
-   bool Open();
+   bool Open(XrdOucCacheIO* inputOrigin);
 
    static const char *m_traceID;
 
@@ -314,9 +314,6 @@ private:
    const std::string    m_filename;     //!< filename of data file on disk
    const long long      m_offset;       //!< offset of cached file for block-based / hdfs operation
    const long long      m_file_size;    //!< size of cached disk file for block-based operation
-
-   // HTTP header cache control
-   const std::string m_cache_control;  //!< cache control values retrived with Fsctl from origin's IO
 
    // IO objects attached to this file.
 
@@ -418,9 +415,6 @@ private:
    bool select_current_io_or_disable_prefetching(bool skip_current);
 
    int  offsetIdx(int idx) const;
-
-   // Http cache directive
-   bool TestCCXAttr();
 };
 
 //------------------------------------------------------------------------------

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -208,7 +208,7 @@ public:
    // Constructor, destructor, Open() and Close() are private.
 
    //! Static constructor that also does Open. Returns null ptr if Open fails.
-   static File* FileOpen(const std::string &path, long long offset, long long fileSize);
+   static File* FileOpen(const std::string &path, long long offset, long long fileSize, const std::string& json);
 
    //! Handle removal of a block from Cache's write queue.
    void BlockRemovedFromWriteQ(Block*);
@@ -292,7 +292,7 @@ public:
 
 private:
    //! Constructor.
-   File(const std::string &path, long long offset, long long fileSize);
+   File(const std::string &path, long long offset, long long fileSize, const std::string& xattrJson);
 
    //! Destructor.
    ~File();
@@ -314,6 +314,9 @@ private:
    const std::string    m_filename;     //!< filename of data file on disk
    const long long      m_offset;       //!< offset of cached file for block-based / hdfs operation
    const long long      m_file_size;    //!< size of cached disk file for block-based operation
+
+   // HTTP header cache control
+   const std::string m_cache_control;  //!< cache control values retrived with Fsctl from origin's IO
 
    // IO objects attached to this file.
 
@@ -415,6 +418,9 @@ private:
    bool select_current_io_or_disable_prefetching(bool skip_current);
 
    int  offsetIdx(int idx) const;
+
+   // Http cache directive
+   bool TestCCXAttr();
 };
 
 //------------------------------------------------------------------------------

--- a/src/XrdPosix/XrdPosixFile.cc
+++ b/src/XrdPosix/XrdPosixFile.cc
@@ -386,6 +386,16 @@ int XrdPosixFile::Fstat(struct stat &buf)
    buf.st_mode   = myMode;
    return 0;
 }
+
+int XrdPosixFile::Fcntl(const XrdCl::Buffer &arg, XrdCl::Buffer *&response)
+{
+   // AMT, how do I check if it is open ?
+   XrdCl::XRootDStatus st = clFile.Fcntl(arg, response);
+
+  // AMT simplify for now. The XRootDStatus shell code is 0 or other positive value
+  //     Do we need to check here for socket errors?
+  return st.GetShellCode();
+}
   
 /******************************************************************************/
 /*                        H a n d l e R e s p o n s e                         */

--- a/src/XrdPosix/XrdPosixFile.cc
+++ b/src/XrdPosix/XrdPosixFile.cc
@@ -389,8 +389,9 @@ int XrdPosixFile::Fstat(struct stat &buf)
 
 int XrdPosixFile::Fcntl(const XrdCl::Buffer &arg, XrdCl::Buffer *&response)
 {
+   // AMT: temporary solution to handle unsuported operations in XrdPfc::File::Open()
    XrdCl::XRootDStatus status = clFile.Fcntl(arg, response);
-   return status.IsOK() ? 0 : -1;
+   return status.IsOK() ? 0 : status.errNo;
 }
   
 /******************************************************************************/

--- a/src/XrdPosix/XrdPosixFile.cc
+++ b/src/XrdPosix/XrdPosixFile.cc
@@ -389,12 +389,8 @@ int XrdPosixFile::Fstat(struct stat &buf)
 
 int XrdPosixFile::Fcntl(const XrdCl::Buffer &arg, XrdCl::Buffer *&response)
 {
-   // AMT, how do I check if it is open ?
-   XrdCl::XRootDStatus st = clFile.Fcntl(arg, response);
-
-  // AMT simplify for now. The XRootDStatus shell code is 0 or other positive value
-  //     Do we need to check here for socket errors?
-  return st.GetShellCode();
+   XrdCl::XRootDStatus status = clFile.Fcntl(arg, response);
+   return status.IsOK() ? 0 : -1;
 }
   
 /******************************************************************************/

--- a/src/XrdPosix/XrdPosixFile.hh
+++ b/src/XrdPosix/XrdPosixFile.hh
@@ -100,6 +100,8 @@ static void          DelayedDestroy(XrdPosixFile *fp);
 
        int           Fstat(struct stat &buf) override;
 
+       int           Fcntl(const XrdCl::Buffer& args, XrdCl::Buffer*& res) override;
+
        const char   *Location(bool refresh=false) override;
 
        void          HandleResponse(XrdCl::XRootDStatus *status,

--- a/src/XrdPosix/XrdPosixPrepIO.hh
+++ b/src/XrdPosix/XrdPosixPrepIO.hh
@@ -48,6 +48,9 @@ long long   FSize() {return (Init() ? fileP->FSize() : openRC);}
 int         Fstat(struct stat &buf)
                  {return (Init() ? fileP->Fstat(buf) : openRC);}
 
+
+virtual int Fcntl(const XrdCl::Buffer& args, XrdCl::Buffer*& res) { return (Init() ? fileP->Fcntl(args, res) : openRC); }
+
 int         Open() {Init(); return openRC;}
 
 const char *Path()  {return fileP->Path();}

--- a/src/XrdPosix/XrdPosixPrepIO.hh
+++ b/src/XrdPosix/XrdPosixPrepIO.hh
@@ -48,8 +48,7 @@ long long   FSize() {return (Init() ? fileP->FSize() : openRC);}
 int         Fstat(struct stat &buf)
                  {return (Init() ? fileP->Fstat(buf) : openRC);}
 
-
-virtual int Fcntl(const XrdCl::Buffer& args, XrdCl::Buffer*& res) { return (Init() ? fileP->Fcntl(args, res) : openRC); }
+int         Fcntl(const XrdCl::Buffer& args, XrdCl::Buffer*& res) { return (Init() ? fileP->Fcntl(args, res) : openRC); }
 
 int         Open() {Init(); return openRC;}
 


### PR DESCRIPTION
This code adds cache-control check using File::Fctnl and FileSystem::Query.
The change is related to pelican-client code https://github.com/PelicanPlatform/xrdcl-pelican/pull/59

